### PR TITLE
update mapping at init

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -61,13 +61,16 @@ ctia.events.log=false
 # Use ES for all Stores
 ctia.store.es.default.host=127.0.0.1
 ctia.store.es.default.port=9200
+#ctia.store.es.default.host=es-storage.int.iroh.site
+#ctia.store.es.default.port=443
+#ctia.store.es.default.transport=https
 ctia.store.es.default.indexname=ctia
 ctia.store.es.default.replicas=1
 ctia.store.es.default.refresh_interval=1s
 ctia.store.es.default.default_operator=AND
 ctia.store.es.default.shards=5
 ctia.store.es.default.refresh=false
-ctia.store.es.default.rollover.max_docs=10000000
+ctia.store.es.default.rollover.max_docs=3
 ctia.store.es.default.aliased=true
 
 ctia.store.actor=es

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -70,7 +70,7 @@ ctia.store.es.default.refresh_interval=1s
 ctia.store.es.default.default_operator=AND
 ctia.store.es.default.shards=5
 ctia.store.es.default.refresh=false
-ctia.store.es.default.rollover.max_docs=3
+ctia.store.es.default.rollover.max_docs=10000000
 ctia.store.es.default.aliased=true
 
 ctia.store.actor=es


### PR DESCRIPTION
In that PR I introduced the ability to select the stores when launching update mapping task.
By the way I added it to the init function to enable CTIA to update it at startup (that way it our case it will ease the process).
The update-mapping also makes the startup fail if an existing mapping update require a migration.